### PR TITLE
Clangarm64 and i686 build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,6 +345,9 @@ ifeq ($(shell _= command -v $(AR)),)
 AR := $(CROSS_COMPILE)gcc-ar
 STRIP := strip
 WINDRES := windres
+ifeq ($(shell _= command -v $(AR)),)
+AR := llvm-ar
+endif
 endif
 endif
 

--- a/archival/tar.c
+++ b/archival/tar.c
@@ -1301,7 +1301,7 @@ int tar_main(int argc UNUSED_PARAM, char **argv)
 	if (ENABLE_FEATURE_CLEAN_UP /* && tar_handle->src_fd != STDIN_FILENO */)
 		close(tar_handle->src_fd);
 
-	if (SEAMLESS_COMPRESSION || OPT_COMPRESS) {
+	if (SEAMLESS_COMPRESSION || (OPT_COMPRESS != 0)) {
 		/* Set bb_got_signal to 1 if a child died with !0 exitcode */
 		check_errors_in_children(0);
 	}

--- a/coreutils/id.c
+++ b/coreutils/id.c
@@ -252,8 +252,9 @@ int id_main(int argc UNUSED_PARAM, char **argv)
 				bb_simple_error_msg_and_die("can't get groups");
 			return EXIT_FAILURE;
 		}
-		if (ENABLE_FEATURE_CLEAN_UP && !ENABLE_PLATFORM_MINGW32)
-			free(groups);
+#if ENABLE_FEATURE_CLEAN_UP && !ENABLE_PLATFORM_MINGW32
+		free(groups);
+#endif
 #if ENABLE_SELINUX
 		if (is_selinux_enabled()) {
 			if (getcon(&scontext) == 0)

--- a/coreutils/install.c
+++ b/coreutils/install.c
@@ -168,7 +168,7 @@ int install_main(int argc, char **argv)
 	}
 #endif
 
-	if ((opts & OPT_v) && FILEUTILS_VERBOSE) {
+	if ((opts & OPT_v) && (FILEUTILS_VERBOSE != 0)) {
 		mkdir_flags |= FILEUTILS_VERBOSE;
 		copy_flags |= FILEUTILS_VERBOSE;
 	}

--- a/coreutils/mkdir.c
+++ b/coreutils/mkdir.c
@@ -80,7 +80,7 @@ int mkdir_main(int argc UNUSED_PARAM, char **argv)
 	}
 	if (opt & 2)
 		flags |= FILEUTILS_RECUR;
-	if ((opt & 4) && FILEUTILS_VERBOSE)
+	if ((opt & 4) && (FILEUTILS_VERBOSE != 0))
 		flags |= FILEUTILS_VERBOSE;
 #if ENABLE_SELINUX
 	if (opt & 8) {

--- a/coreutils/od_bloaty.c
+++ b/coreutils/od_bloaty.c
@@ -265,12 +265,19 @@ static const unsigned char integral_type_size[MAX_INTEGRAL_TYPE_SIZE + 1] ALIGN1
 };
 
 #define MAX_FP_TYPE_SIZE sizeof(longdouble_t)
+#ifdef __clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winitializer-overrides"
+#endif
 static const unsigned char fp_type_size[MAX_FP_TYPE_SIZE + 1] ALIGN1 = {
 	/* gcc seems to allow repeated indexes. Last one wins */
 	[sizeof(longdouble_t)] = FLOAT_LONG_DOUBLE,
 	[sizeof(double)] = FLOAT_DOUBLE,
 	[sizeof(float)] = FLOAT_SINGLE
 };
+#ifdef __clang__
+#pragma GCC diagnostic pop
+#endif
 
 
 static unsigned

--- a/coreutils/rm.c
+++ b/coreutils/rm.c
@@ -54,7 +54,7 @@ int rm_main(int argc UNUSED_PARAM, char **argv)
 		flags |= FILEUTILS_INTERACTIVE;
 	if (opt & (8|4))
 		flags |= FILEUTILS_RECUR;
-	if ((opt & 16) && FILEUTILS_VERBOSE)
+	if ((opt & 16) && (FILEUTILS_VERBOSE != 0))
 		flags |= FILEUTILS_VERBOSE;
 
 	if (*argv != NULL) {

--- a/libbb/hash_md5_sha.c
+++ b/libbb/hash_md5_sha.c
@@ -180,6 +180,7 @@ struct ASM_expects_80_shaNI { char t[1 - 2*(offsetof(sha256_ctx_t, hash) != 80)]
  * in gcc, while inline basically forces it to happen.
  */
 //#define rotl32(x,n) (((x) << (n)) | ((x) >> (32 - (n))))
+#if !ENABLE_FEATURE_USE_CNG_API
 static ALWAYS_INLINE uint32_t rotl32(uint32_t x, unsigned n)
 {
 	return (x << n) | (x >> (32 - n));
@@ -195,6 +196,7 @@ static ALWAYS_INLINE uint64_t rotr64(uint64_t x, unsigned n)
 {
 	return (x >> n) | (x << (64 - n));
 }
+#endif /* !ENABLE_FEATURE_USE_CNG_API */
 
 /* rotl64 only used for sha3 currently */
 static ALWAYS_INLINE uint64_t rotl64(uint64_t x, unsigned n)

--- a/miscutils/bc.c
+++ b/miscutils/bc.c
@@ -4242,7 +4242,7 @@ static BC_STATUS zbc_parse_if(void)
 {
 	BcParse *p = &G.prs;
 	BcStatus s;
-	size_t ip_idx;
+	size_t ip_idx = 0;
 
 	dbg_lex_enter("%s:%d entered", __func__, __LINE__);
 	s = zxc_lex_next();
@@ -4266,7 +4266,7 @@ static BC_STATUS zbc_parse_if(void)
 
 	dbg_lex("%s:%d in if after stmt: p->lex:%d", __func__, __LINE__, p->lex);
 	if (p->lex == BC_LEX_KEY_ELSE) {
-		size_t ip2_idx;
+		size_t ip2_idx = 0;
 
 		// Encode "after then_stmt, jump to end of if()"
 		ip2_idx = bc_vec_push(&p->func->labels, &ip2_idx);

--- a/shell/ash.c
+++ b/shell/ash.c
@@ -3425,7 +3425,7 @@ updatepwd(const char *dir)
 
 	cdcomppath = sstrdup(dir);
 	STARTSTACKSTR(new);
-	if (!target == ABS_DRIVE && is_dir_sep(*dir))
+	if (!(target == ABS_DRIVE) && is_dir_sep(*dir))
 		return 0;
 
 	switch (target) {

--- a/win32/mingw.c
+++ b/win32/mingw.c
@@ -2142,8 +2142,6 @@ static wchar_t *resolve_symlinks(wchar_t *wpath)
  */
 static wchar_t * FAST_FUNC wrealpath(wchar_t *wpath, wchar_t *resolved_path)
 {
-	wchar_t *real_path;
-
 	/* enforce glibc pre-2.3 behaviour */
 	if (wpath == NULL || resolved_path == NULL) {
 		errno = EINVAL;
@@ -2154,9 +2152,9 @@ static wchar_t * FAST_FUNC wrealpath(wchar_t *wpath, wchar_t *resolved_path)
 	    (resolved_path = resolve_symlinks(resolved_path))) {
 		size_t len = wcslen(resolved_path);
 
-		if (len > 0 && real_path[len - 1] == L'\\' &&
-		    (len < 2 || real_path[len - 2] != L':'))
-			real_path[len - 1] = L'\0';
+		if (len > 0 && resolved_path[len - 1] == L'\\' &&
+		    (len < 2 || resolved_path[len - 2] != L':'))
+			resolved_path[len - 1] = L'\0';
 
 		return resolved_path;
 	}

--- a/win32/mingw.c
+++ b/win32/mingw.c
@@ -49,7 +49,9 @@ unsigned int _CRT_fmode = _O_BINARY;
 smallint bb_got_signal;
 static mode_t current_umask = DEFAULT_UMASK;
 
+#ifndef __clang__
 #pragma GCC optimize ("no-if-conversion")
+#endif
 
 static inline int wisdirsep(wchar_t w)
 {
@@ -425,7 +427,9 @@ int err_win_to_posix(void)
 	}
 	return error;
 }
+#ifndef __clang__
 #pragma GCC reset_options
+#endif
 
 #undef strerror
 char * FAST_FUNC mingw_strerror(int errnum)

--- a/win32/mingw.c
+++ b/win32/mingw.c
@@ -135,7 +135,7 @@ static wchar_t *pathconv_rest(wchar_t *result, int offset, const char *path)
 }
 
 /* This function is not thread safe. Does it need to be? */
-wchar_t *mingw_pathconv(const char *path)
+wchar_t * FAST_FUNC mingw_pathconv(const char *path)
 {
 	static wchar_t pseudo_root[PATH_MAX];
 #define MAX_CONCURRENT_PATHCONV 64
@@ -2180,7 +2180,7 @@ static inline int wcstoutf(wchar_t *in, char *out, size_t size)
 	return 0;
 }
 
-char *realpath(const char *path, char *resolved_path)
+char * FAST_FUNC realpath(const char *path, char *resolved_path)
 {
 	wchar_t *wpath = mingw_pathconv(path);
 	wchar_t buffer[PATH_MAX_LONG];

--- a/win32/process.c
+++ b/win32/process.c
@@ -122,7 +122,7 @@ static void exit_process_on_signal(HANDLE process)
 	LeaveCriticalSection(&spawned_processes.mutex);
 }
 
-void initialize_critical_sections(void)
+void FAST_FUNC initialize_critical_sections(void)
 {
 	InitializeCriticalSection(&spawned_processes.mutex);
 	atexit(kill_spawned_processes_on_signal);


### PR DESCRIPTION
These fixes are required to build BusyBox for mingw32 again, and now also for clangarm64.